### PR TITLE
Read session cookie from config

### DIFF
--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -76,6 +76,8 @@ type WebAppConfig struct {
 type CloudAssistantConfig struct {
 	// VectorStores is the list of vector stores to use
 	VectorStores []string `json:"vectorStores,omitempty" yaml:"vectorStores,omitempty"`
+	// SessionCookie is the value of the cassie-session cookie used for evaluation
+	SessionCookie string `json:"sessionCookie,omitempty" yaml:"sessionCookie,omitempty"`
 }
 
 type OpenAIConfig struct {


### PR DESCRIPTION
## Summary
- load session cookie value from YAML config (`cloudAssistant.sessionCookie`)
- use this value for the cassie-session cookie in eval client

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.20.0.3:8080: connect: no route to host)*


------
https://chatgpt.com/codex/tasks/task_i_683cd4007d908321ba77e2f420fb046f